### PR TITLE
升级pingpp-java版本到2.3.10，原先的版本在maven中央仓库不存在

### DIFF
--- a/pay/pay-service-impl/pom.xml
+++ b/pay/pay-service-impl/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>Pingplusplus</groupId>
             <artifactId>pingpp-java</artifactId>
-            <version>2.2.4</version>
+            <version>2.3.10</version>
             <type>jar</type>
         </dependency>
 


### PR DESCRIPTION
pingpp-java版本2.2.4在中央仓库不存在，给开发者带来麻烦